### PR TITLE
Refactored to work with multiple CommaSeparated query parameters.

### DIFF
--- a/Strathweb.Samples.AspNetCore.QueryStringBinding/CommaSeparatedQueryStringConvention.cs
+++ b/Strathweb.Samples.AspNetCore.QueryStringBinding/CommaSeparatedQueryStringConvention.cs
@@ -7,11 +7,18 @@ namespace Strathweb.Samples.AspNetCore.QueryStringBinding
     {
         public void Apply(ActionModel action)
         {
+            SeparatedQueryStringAttribute attribute = null;
             foreach (var parameter in action.Parameters)
             {
-                if (parameter.Attributes.OfType<CommaSeparatedAttribute>().Any() && !parameter.Action.Filters.OfType<SeparatedQueryStringAttribute>().Any())
+                if (parameter.Attributes.OfType<CommaSeparatedAttribute>().Any())
                 {
-                    parameter.Action.Filters.Add(new SeparatedQueryStringAttribute(parameter.ParameterName, ","));
+                    if (attribute == null)
+                    {
+                        attribute = new SeparatedQueryStringAttribute(",");
+                        parameter.Action.Filters.Add(attribute);
+                    }
+
+                    attribute.AddKey(parameter.ParameterName);
                 }
             }
         }

--- a/Strathweb.Samples.AspNetCore.QueryStringBinding/SeparatedQueryStringAttribute.cs
+++ b/Strathweb.Samples.AspNetCore.QueryStringBinding/SeparatedQueryStringAttribute.cs
@@ -8,9 +8,7 @@ namespace Strathweb.Samples.AspNetCore.QueryStringBinding
     {
         private readonly SeparatedQueryStringValueProviderFactory _factory;
 
-        public SeparatedQueryStringAttribute() : this(",")
-        {
-        }
+        public SeparatedQueryStringAttribute() : this(",") { }
 
         public SeparatedQueryStringAttribute(string separator)
         {
@@ -24,11 +22,17 @@ namespace Strathweb.Samples.AspNetCore.QueryStringBinding
 
         public void OnResourceExecuted(ResourceExecutedContext context)
         {
+
         }
 
         public void OnResourceExecuting(ResourceExecutingContext context)
         {
             context.ValueProviderFactories.Insert(0, _factory);
+        }
+
+        public void AddKey(string key)
+        {
+            _factory.AddKey(key);
         }
     }
 }

--- a/Strathweb.Samples.AspNetCore.QueryStringBinding/SeparatedQueryStringValueProviderFactory.cs
+++ b/Strathweb.Samples.AspNetCore.QueryStringBinding/SeparatedQueryStringValueProviderFactory.cs
@@ -6,22 +6,37 @@ namespace Strathweb.Samples.AspNetCore.QueryStringBinding
     public class SeparatedQueryStringValueProviderFactory : IValueProviderFactory
     {
         private readonly string _separator;
-        private readonly string _key;
+        private HashSet<string> _keys;
 
-        public SeparatedQueryStringValueProviderFactory(string separator) : this(null, separator)
+        public SeparatedQueryStringValueProviderFactory(string separator) : this((IEnumerable<string>)null, separator)
+        { }
+
+        public SeparatedQueryStringValueProviderFactory(string key, string separator) : this(new List<string> { key }, separator)
         {
         }
 
-        public SeparatedQueryStringValueProviderFactory(string key, string separator)
+        public SeparatedQueryStringValueProviderFactory(IEnumerable<string> keys, string separator)
         {
-            _key = key;
+            _keys = keys != null ? new HashSet<string>(keys) : null;
             _separator = separator;
         }
 
         public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
         {
-            context.ValueProviders.Insert(0, new SeparatedQueryStringValueProvider(_key, context.ActionContext.HttpContext.Request.Query, _separator));
+            context.ValueProviders.Insert(0,
+                new SeparatedQueryStringValueProvider(_keys, context.ActionContext.HttpContext.Request.Query,
+                    _separator));
             return Task.CompletedTask;
+        }
+
+        public void AddKey(string key)
+        {
+            if (_keys == null)
+            {
+                _keys = new HashSet<string>();
+            }
+
+            _keys.Add(key);
         }
     }
 }


### PR DESCRIPTION
1. CommaSeparatedQueryStringConvention:
   a. Added single SeparatedQueryStringAttribute object to be used while looping through each parameter.
   b. Removed second check in if statement to allow for handling of multiple parameters with attribute.
   c. Utilized new "AddKey()" method of SeparatedQueryStringAttribute to add keys with attribute.
2. SeparatedQueryStringAttribute:
   a. Added new method, AddKey(string), to add additional strings to the keys to be used in SeparatedQueryStringValueProviderFactory
3. SeparatedQueryStringValueProviderFactory:
   a. Changed string _key to HashSet<string> _keys to hold list of keys to be checked rather than single key.
   b. Added new constructor to take IEnumerable<string> to initialize the _keys variable.
   c. Refactored current constructor(string, string) to use newly created constructor.
   d. Refactored CreateValueProviderAsync(ValueProviderFactorContext) method to use newly created constructor in SeparatedQueryStringValueProvider which handles IEnumerable of keys.
   e. Added AddKey(string) method to add new keys to _keys HashSet.
4. SeparatedQueryStringValueProvider:
   a. Changed string _key to HashSet<string> _keys to hold list of keys to be checked rather than single key.
   b. Added new constructor to take IEnumerable<string> to initialize the _keys variable.
   c. Refactored constructor(string, IQueryCollection, string) to use new constructor to intialize _keys.
   d. Refactored GetValue(string) to check if HashSet contains key being checked rather than testing against single _key.